### PR TITLE
feat: add opencode-tts to bulk plugin list

### DIFF
--- a/bulk/plugins.json
+++ b/bulk/plugins.json
@@ -128,5 +128,15 @@
     "homepageUrl": "https://github.com/code-yeongyu/oh-my-opencode",
     "tags": ["agents", "lsp", "ast", "mcp", "claude-code", "orchestration"],
     "installation": "## Installation\n\nAdd to your OpenCode config:\n\n```bash\nmkdir -p ~/.config/opencode\n```\n\nIf `~/.config/opencode/opencode.json` exists, add `oh-my-opencode` to the plugin array. Otherwise create:\n\n```json\n{\n  \"plugin\": [\"oh-my-opencode\"]\n}\n```\n\nThen run:\n\n```bash\nopencode auth login\n```\n\nConfigure authentication for your preferred providers (Anthropic, Google, OpenAI)."
+  },
+  {
+    "productId": "opencode-tts",
+    "type": "plugin",
+    "displayName": "OpenCode TTS",
+    "description": "Speak idle assistant responses aloud with summary or full-text modes, slash commands, and local Edge TTS or system voice backends",
+    "repoUrl": "https://github.com/StefanoChiodino/opencode-tts",
+    "homepageUrl": "https://github.com/StefanoChiodino/opencode-tts",
+    "tags": ["tts", "voice", "audio", "summaries", "notifications"],
+    "installation": "## Installation\n\nAdd the plugin to your OpenCode config:\n\n```json\n{\n  \"$schema\": \"https://opencode.ai/config.json\",\n  \"plugin\": [\"opencode-tts\"]\n}\n```\n\nRestart OpenCode. The plugin will auto-speak each idle assistant response, and you can control it with `/tts-on`, `/tts-off`, `/tts-mode-summary`, `/tts-mode-full`, and `/tts-repeat`."
   }
 ]


### PR DESCRIPTION
## Summary
- add `opencode-tts` to the bulk plugin seed list used for opencode.cafe imports
- include install instructions and control commands so the entry can be imported into the site catalog

## Test Plan
- `bun install`
- `node -e "JSON.parse(require('node:fs').readFileSync('bulk/plugins.json','utf8'))"`
- `bun run lint` (passes with existing warnings)
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenCode TTS plugin to the registry, enabling text-to-speech functionality within the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->